### PR TITLE
Do not fail when cleaning twice

### DIFF
--- a/lib_eigsolve/Makefile
+++ b/lib_eigsolve/Makefile
@@ -30,4 +30,4 @@ lib_eigsolve.a: $(OBJS)
 	ar -cr lib_eigsolve.a $(OBJS)
 
 clean:
-	rm lib_eigsolve.a *.mod *.o
+	rm -f lib_eigsolve.a *.mod *.o


### PR DESCRIPTION
This is useful when embedding the library in a more extended build system.